### PR TITLE
Remove tests that cannot be run now g-cloud-12 is expired

### DIFF
--- a/config.js
+++ b/config.js
@@ -75,18 +75,18 @@ module.exports = {
     },
 
 
-    {
-      "label": environment + ": G-Cloud - start",
-      "url": domain + "/buyers/direct-award/g-cloud/start"
-    },
-    {
-      "label": environment + ": G-Cloud - lots",
-      "url": domain + "/buyers/direct-award/g-cloud/choose-lot"
-    },
-    {
-      "label": environment + ": G-Cloud - Cloud hosting search results",
-      "url": domain + "/g-cloud/search?lot=cloud-hosting&serviceCategories=container+service"
-    },
+    // {
+    //   "label": environment + ": G-Cloud - start",
+    //   "url": domain + "/buyers/direct-award/g-cloud/start"
+    // },
+    // {
+    //   "label": environment + ": G-Cloud - lots",
+    //   "url": domain + "/buyers/direct-award/g-cloud/choose-lot"
+    // },
+    // {
+    //   "label": environment + ": G-Cloud - Cloud hosting search results",
+    //   "url": domain + "/g-cloud/search?lot=cloud-hosting&serviceCategories=container+service"
+    // },
     {
       "label": environment + ": G-Cloud - Supplier listing",
       "url": domain + "/g-cloud/suppliers"


### PR DESCRIPTION
I have removed/fixed some tests that were not working due to g-cloud-12 not being live anymore.
I've also updated Ruby to the latest version