### PR TITLE
Revert "Add dependabot check for GitHub Actions"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,3 @@ updates:
     interval: weekly
     time: "03:00"
   open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "03:00"


### PR DESCRIPTION
Reverts Crown-Commercial-Service/digitalmarketplace-visual-regression#95

I now realise that this is not necessary 